### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,6 +1,8 @@
 # This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
 name: CMake on multiple platforms
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ConnorC432/wordle-solved/security/code-scanning/1](https://github.com/ConnorC432/wordle-solved/security/code-scanning/1)

To fix the problem, explicitly specify the least-privilege permissions required for the workflow by adding a `permissions` block. The minimal required permission for a standard build-and-test workflow is `contents: read`, which allows the workflow to checkout code but prevents write operations and modifications to the repository or its metadata. The best location for this is at the root level of the workflow YAML file, directly below the `name:` or `on:` key, so all jobs inherit it. No changes to code logic, jobs, or steps are needed; only a single YAML key addition is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
